### PR TITLE
FCM Admin Key 파일을 외부 url을 통해 불러와 읽는 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
 	implementation("io.github.openfeign:feign-core:11.8")
 	implementation("io.github.openfeign:feign-jackson:11.8")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+	implementation("com.google.firebase:firebase-admin:9.1.1")
 }
 
 dependencyManagement {

--- a/src/main/kotlin/com/ondosee/global/config/FcmConfig.kt
+++ b/src/main/kotlin/com/ondosee/global/config/FcmConfig.kt
@@ -26,10 +26,10 @@ class FcmConfig(
                 Files.copy(it, Paths.get(PATH))
                 val file = File(PATH)
                 if (FirebaseApp.getApps().isEmpty()) {
-                    val options = FirebaseOptions.builder()
+                    FirebaseOptions.builder()
                         .setCredentials(GoogleCredentials.fromStream(file.inputStream()))
                         .build()
-                    FirebaseApp.initializeApp(options)
+                        .run(FirebaseApp::initializeApp)
                 }
                 file.delete()
             }

--- a/src/main/kotlin/com/ondosee/global/config/FcmConfig.kt
+++ b/src/main/kotlin/com/ondosee/global/config/FcmConfig.kt
@@ -1,0 +1,40 @@
+package com.ondosee.global.config
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.ondosee.global.config.properties.FcmProperties
+import org.springframework.context.annotation.Configuration
+import java.io.File
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Paths
+import javax.annotation.PostConstruct
+
+@Configuration
+class FcmConfig(
+    private val fcmProperties: FcmProperties
+) {
+    companion object {
+        const val PATH = "./credentials.json"
+    }
+
+    @PostConstruct
+    fun init() {
+        runCatching {
+            URL(fcmProperties.url).openStream().use {
+                Files.copy(it, Paths.get(PATH))
+                val file = File(PATH)
+                if (FirebaseApp.getApps().isEmpty()) {
+                    val options = FirebaseOptions.builder()
+                        .setCredentials(GoogleCredentials.fromStream(file.inputStream()))
+                        .build()
+                    FirebaseApp.initializeApp(options)
+                }
+                file.delete()
+            }
+        }.onFailure {
+            it.printStackTrace()
+        }
+    }
+}

--- a/src/main/kotlin/com/ondosee/global/config/FcmConfig.kt
+++ b/src/main/kotlin/com/ondosee/global/config/FcmConfig.kt
@@ -24,15 +24,15 @@ class FcmConfig(
         runCatching {
             URL(fcmProperties.url).openStream().use {
                 Files.copy(it, Paths.get(PATH))
-                val file = File(PATH)
-                if (FirebaseApp.getApps().isEmpty()) {
-                    FirebaseOptions.builder()
-                        .setCredentials(GoogleCredentials.fromStream(file.inputStream()))
-                        .build()
-                        .run(FirebaseApp::initializeApp)
-                }
-                file.delete()
             }
+            val file = File(PATH)
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(file.inputStream()))
+                    .build()
+                    .run(FirebaseApp::initializeApp)
+            }
+            file.delete()
         }.onFailure {
             it.printStackTrace()
         }

--- a/src/main/kotlin/com/ondosee/global/config/properties/FcmProperties.kt
+++ b/src/main/kotlin/com/ondosee/global/config/properties/FcmProperties.kt
@@ -1,0 +1,10 @@
+package com.ondosee.global.config.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConfigurationProperties(prefix = "fcm")
+@ConstructorBinding
+class FcmProperties(
+    val url: String
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,19 @@ dataporter:
 
 openweather:
   key: ${OPENWATER_KEY}
+
+fcm:
+  url: ${FCM_URL}
+
+cloud:
+  aws:
+    region:
+      static: ${AWS_REGION}
+    credentials:
+      access-key: ${AWS_ACCESS}
+      secret-key: ${AWS_SECRET}
+    s3:
+      bucket: ${AWS_BUCKET_NAME}
+      url: ${AWS_URL}
+    stack:
+      auto: false


### PR DESCRIPTION
푸시 알림을 전송하는 권한을 가진 FCM Admin Key 값을 저장하는 기능을 구현했습니다.

---

FCM Admin Key를 저장하는 방법 중 단순히 해당 Key 파일을 프로젝트( resources 패키지 등 ) 내에 삽입 시키는 방법이 있지만 보안적인 측면 및 프로젝트 파일 자체가 무거워지는 문제를 방지하고자 해당 파일을 S3 버킷에 업로드 후 해당 파일의 AWS 주소를 불러와 읽는 방법을 사용하여 해당 기능을 구현했습니다.

---

아직 푸시 알림 기능이 완전히 구현되어 있지 않아 단순히 Key 파일만 프로젝트 내에 저장하고 있는 상태라서 푸시 알림 기능을 마저 구현하면서 제대로 작동하지 않는 부분이 있다면 추가로 수정하여 보완하겠습니다..!!