### PR TITLE
알림 시간 설정 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	runtimeOnly("org.mariadb.jdbc:mariadb-java-client")

--- a/src/main/kotlin/com/ondosee/common/adapter/notification/CommandNotificationAdapter.kt
+++ b/src/main/kotlin/com/ondosee/common/adapter/notification/CommandNotificationAdapter.kt
@@ -15,7 +15,6 @@ class CommandNotificationAdapter(
 
     override fun saveAlarm(deviceToken: String, alarmTime: String) {
         val notification = Notification(
-            id = 0L,
             deviceToken = deviceToken,
             alarmTime = alarmTime
         )

--- a/src/main/kotlin/com/ondosee/common/adapter/notification/CommandNotificationAdapter.kt
+++ b/src/main/kotlin/com/ondosee/common/adapter/notification/CommandNotificationAdapter.kt
@@ -1,22 +1,25 @@
 package com.ondosee.common.adapter.notification
 
 import com.ondosee.common.spi.notification.CommandNotificationPort
-import com.ondosee.common.spi.notification.QueryNotificationPort
 import com.ondosee.domain.notification.domain.entity.Notification
+import com.ondosee.domain.notification.domain.repository.NotificationRepository
 import org.springframework.stereotype.Component
 
 @Component
 class CommandNotificationAdapter(
-    private val queryNotificationPort: QueryNotificationPort
+    private val notificationRepository: NotificationRepository
 ) : CommandNotificationPort {
+    override fun deleteDeviceToken(notification: Notification) {
+        notificationRepository.delete(notification)
+    }
 
-    override fun saveDeviceToken(deviceToken: String) {
-
+    override fun saveAlarm(deviceToken: String, alarmTime: String) {
         val notification = Notification(
+            id = 0L,
             deviceToken = deviceToken,
-            alarmTime = null
+            alarmTime = alarmTime
         )
 
-        queryNotificationPort.saveNotification(notification)
+        notificationRepository.save(notification)
     }
 }

--- a/src/main/kotlin/com/ondosee/common/adapter/notification/CommandNotificationAdapter.kt
+++ b/src/main/kotlin/com/ondosee/common/adapter/notification/CommandNotificationAdapter.kt
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Component
 class CommandNotificationAdapter(
     private val notificationRepository: NotificationRepository
 ) : CommandNotificationPort {
-    override fun deleteDeviceToken(notification: Notification) {
-        notificationRepository.delete(notification)
+    override fun deleteByDeviceToken(deviceToken: String) {
+        notificationRepository.deleteByDeviceToken(deviceToken)
     }
 
     override fun saveAlarm(deviceToken: String, alarmTime: String) {

--- a/src/main/kotlin/com/ondosee/common/adapter/notification/QueryNotificationAdapter.kt
+++ b/src/main/kotlin/com/ondosee/common/adapter/notification/QueryNotificationAdapter.kt
@@ -1,7 +1,6 @@
 package com.ondosee.common.adapter.notification
 
 import com.ondosee.common.spi.notification.QueryNotificationPort
-import com.ondosee.domain.notification.domain.entity.Notification
 import com.ondosee.domain.notification.domain.repository.NotificationRepository
 import org.springframework.stereotype.Component
 
@@ -9,7 +8,7 @@ import org.springframework.stereotype.Component
 class QueryNotificationAdapter(
     private val notificationRepository: NotificationRepository
 ) : QueryNotificationPort {
-    override fun findByDeviceToken(deviceToken: String): Notification? {
-        return notificationRepository.findByDeviceToken(deviceToken)
+    override fun existByDeviceToken(deviceToken: String): Boolean {
+        return notificationRepository.existsByDeviceToken(deviceToken)
     }
 }

--- a/src/main/kotlin/com/ondosee/common/adapter/notification/QueryNotificationAdapter.kt
+++ b/src/main/kotlin/com/ondosee/common/adapter/notification/QueryNotificationAdapter.kt
@@ -9,9 +9,7 @@ import org.springframework.stereotype.Component
 class QueryNotificationAdapter(
     private val notificationRepository: NotificationRepository
 ) : QueryNotificationPort {
-
-    override fun saveNotification(notification: Notification): Notification {
-
-        return notificationRepository.save(notification)
+    override fun findByDeviceToken(deviceToken: String): Notification? {
+        return notificationRepository.findByDeviceToken(deviceToken)
     }
 }

--- a/src/main/kotlin/com/ondosee/common/spi/notification/CommandNotificationPort.kt
+++ b/src/main/kotlin/com/ondosee/common/spi/notification/CommandNotificationPort.kt
@@ -1,5 +1,8 @@
 package com.ondosee.common.spi.notification
 
+import com.ondosee.domain.notification.domain.entity.Notification
+
 interface CommandNotificationPort {
-    fun saveDeviceToken(deviceToken: String)
+    fun deleteDeviceToken(notification: Notification)
+    fun saveAlarm(deviceToken: String, alarmTime: String)
 }

--- a/src/main/kotlin/com/ondosee/common/spi/notification/CommandNotificationPort.kt
+++ b/src/main/kotlin/com/ondosee/common/spi/notification/CommandNotificationPort.kt
@@ -1,8 +1,6 @@
 package com.ondosee.common.spi.notification
 
-import com.ondosee.domain.notification.domain.entity.Notification
-
 interface CommandNotificationPort {
-    fun deleteDeviceToken(notification: Notification)
+    fun deleteByDeviceToken(deviceToken: String)
     fun saveAlarm(deviceToken: String, alarmTime: String)
 }

--- a/src/main/kotlin/com/ondosee/common/spi/notification/QueryNotificationPort.kt
+++ b/src/main/kotlin/com/ondosee/common/spi/notification/QueryNotificationPort.kt
@@ -1,7 +1,5 @@
 package com.ondosee.common.spi.notification
 
-import com.ondosee.domain.notification.domain.entity.Notification
-
 interface QueryNotificationPort {
-    fun findByDeviceToken(deviceToken: String): Notification?
+    fun existByDeviceToken(deviceToken: String): Boolean
 }

--- a/src/main/kotlin/com/ondosee/common/spi/notification/QueryNotificationPort.kt
+++ b/src/main/kotlin/com/ondosee/common/spi/notification/QueryNotificationPort.kt
@@ -3,5 +3,5 @@ package com.ondosee.common.spi.notification
 import com.ondosee.domain.notification.domain.entity.Notification
 
 interface QueryNotificationPort {
-    fun saveNotification(notification: Notification): Notification
+    fun findByDeviceToken(deviceToken: String): Notification?
 }

--- a/src/main/kotlin/com/ondosee/domain/notification/domain/entity/Notification.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/domain/entity/Notification.kt
@@ -1,6 +1,5 @@
 package com.ondosee.domain.notification.domain.entity
 
-import java.time.LocalDateTime
 import javax.persistence.*
 
 @Entity
@@ -9,11 +8,13 @@ data class Notification(
     @Id
     @Column(name = "notification_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0,
+    val id: Long,
 
     @Column(name = "device_token")
     val deviceToken: String,
 
     @Column(name = "alarm_time")
-    var alarmTime: LocalDateTime?
-)
+    val alarmTime: String?
+) {
+    constructor() : this(0, "", null)
+}

--- a/src/main/kotlin/com/ondosee/domain/notification/domain/entity/Notification.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/domain/entity/Notification.kt
@@ -8,13 +8,11 @@ data class Notification(
     @Id
     @Column(name = "notification_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long,
+    val id: Long = 0,
 
     @Column(name = "device_token")
-    val deviceToken: String,
+    val deviceToken: String = "",
 
     @Column(name = "alarm_time")
-    val alarmTime: String?
-) {
-    constructor() : this(0, "", null)
-}
+    val alarmTime: String? = null
+)

--- a/src/main/kotlin/com/ondosee/domain/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/domain/repository/NotificationRepository.kt
@@ -4,5 +4,6 @@ import com.ondosee.domain.notification.domain.entity.Notification
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface NotificationRepository : JpaRepository<Notification, Long> {
-    fun findByDeviceToken(deviceToken: String): Notification?
+    fun existsByDeviceToken(deviceToken: String): Boolean
+    fun deleteByDeviceToken(deviceToken: String)
 }

--- a/src/main/kotlin/com/ondosee/domain/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/domain/repository/NotificationRepository.kt
@@ -1,7 +1,8 @@
 package com.ondosee.domain.notification.domain.repository
 
 import com.ondosee.domain.notification.domain.entity.Notification
-import org.springframework.data.repository.CrudRepository
+import org.springframework.data.jpa.repository.JpaRepository
 
-interface NotificationRepository : CrudRepository<Notification, Long> {
+interface NotificationRepository : JpaRepository<Notification, Long> {
+    fun findByDeviceToken(deviceToken: String): Notification?
 }

--- a/src/main/kotlin/com/ondosee/domain/notification/presentation/NotificationController.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/presentation/NotificationController.kt
@@ -1,12 +1,13 @@
 package com.ondosee.domain.notification.presentation
 
+import com.ondosee.domain.notification.presentation.web.req.SetAlarmWebRequest
 import com.ondosee.domain.notification.service.NotificationService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/notification")
@@ -14,7 +15,7 @@ class NotificationController(
     private val notificationService: NotificationService
 ) {
     @PostMapping
-    fun saveNotification(@RequestParam deviceToken: String): ResponseEntity<Void> =
-        notificationService.saveNotification(deviceToken)
+    fun setAlarm(@Valid webRequest: SetAlarmWebRequest): ResponseEntity<Void> =
+        notificationService.setAlarm(webRequest)
             .let { ResponseEntity.status(HttpStatus.CREATED).build() }
 }

--- a/src/main/kotlin/com/ondosee/domain/notification/presentation/NotificationController.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/presentation/NotificationController.kt
@@ -5,6 +5,7 @@ import com.ondosee.domain.notification.service.NotificationService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import javax.validation.Valid
@@ -15,7 +16,7 @@ class NotificationController(
     private val notificationService: NotificationService
 ) {
     @PostMapping
-    fun setAlarm(@Valid webRequest: SetAlarmWebRequest): ResponseEntity<Unit> =
+    fun setAlarm(@Valid @RequestBody webRequest: SetAlarmWebRequest): ResponseEntity<Unit> =
         notificationService.setAlarm(webRequest)
             .let { ResponseEntity.status(HttpStatus.CREATED).build() }
 }

--- a/src/main/kotlin/com/ondosee/domain/notification/presentation/NotificationController.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/presentation/NotificationController.kt
@@ -15,7 +15,7 @@ class NotificationController(
     private val notificationService: NotificationService
 ) {
     @PostMapping
-    fun setAlarm(@Valid webRequest: SetAlarmWebRequest): ResponseEntity<Void> =
+    fun setAlarm(@Valid webRequest: SetAlarmWebRequest): ResponseEntity<Unit> =
         notificationService.setAlarm(webRequest)
             .let { ResponseEntity.status(HttpStatus.CREATED).build() }
 }

--- a/src/main/kotlin/com/ondosee/domain/notification/presentation/web/req/SetAlarmWebRequest.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/presentation/web/req/SetAlarmWebRequest.kt
@@ -1,13 +1,10 @@
 package com.ondosee.domain.notification.presentation.web.req
 
-import org.springframework.web.bind.annotation.RequestParam
 import javax.validation.constraints.Pattern
 
 data class SetAlarmWebRequest(
-    @RequestParam
     val deviceToken: String,
 
-    @RequestParam
     @field:Pattern(regexp = "^([01]\\d|2[0-3]):([0-5]\\d)$")
     val alarmTime: String
 )

--- a/src/main/kotlin/com/ondosee/domain/notification/presentation/web/req/SetAlarmWebRequest.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/presentation/web/req/SetAlarmWebRequest.kt
@@ -1,0 +1,13 @@
+package com.ondosee.domain.notification.presentation.web.req
+
+import org.springframework.web.bind.annotation.RequestParam
+import javax.validation.constraints.Pattern
+
+data class SetAlarmWebRequest(
+    @RequestParam
+    val deviceToken: String,
+
+    @RequestParam
+    @field:Pattern(regexp = "^([01]\\d|2[0-3]):([0-5]\\d)$")
+    val alarmTime: String
+)

--- a/src/main/kotlin/com/ondosee/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/service/NotificationService.kt
@@ -1,5 +1,7 @@
 package com.ondosee.domain.notification.service
 
+import com.ondosee.domain.notification.presentation.web.req.SetAlarmWebRequest
+
 interface NotificationService {
-    fun saveNotification(deviceToken: String)
+    fun setAlarm(webRequest: SetAlarmWebRequest)
 }

--- a/src/main/kotlin/com/ondosee/domain/notification/service/NotificationServiceImpl.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/service/NotificationServiceImpl.kt
@@ -4,16 +4,18 @@ import com.ondosee.common.spi.notification.CommandNotificationPort
 import com.ondosee.common.spi.notification.QueryNotificationPort
 import com.ondosee.domain.notification.presentation.web.req.SetAlarmWebRequest
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
+@Transactional(rollbackFor = [Exception::class])
 class NotificationServiceImpl(
     private val queryNotificationPort: QueryNotificationPort,
     private val commandNotificationPort: CommandNotificationPort
 ) : NotificationService {
     override fun setAlarm(webRequest: SetAlarmWebRequest) {
         with(webRequest) {
-            queryNotificationPort.findByDeviceToken(deviceToken)?.let {
-                commandNotificationPort.deleteDeviceToken(it)
+            if (queryNotificationPort.existByDeviceToken(deviceToken)) {
+                commandNotificationPort.deleteByDeviceToken(deviceToken)
             }
 
             commandNotificationPort.saveAlarm(deviceToken, alarmTime)

--- a/src/main/kotlin/com/ondosee/domain/notification/service/NotificationServiceImpl.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/service/NotificationServiceImpl.kt
@@ -1,13 +1,22 @@
 package com.ondosee.domain.notification.service
 
 import com.ondosee.common.spi.notification.CommandNotificationPort
+import com.ondosee.common.spi.notification.QueryNotificationPort
+import com.ondosee.domain.notification.presentation.web.req.SetAlarmWebRequest
 import org.springframework.stereotype.Service
 
 @Service
 class NotificationServiceImpl(
+    private val queryNotificationPort: QueryNotificationPort,
     private val commandNotificationPort: CommandNotificationPort
 ) : NotificationService {
-    override fun saveNotification(deviceToken: String) {
-        commandNotificationPort.saveDeviceToken(deviceToken)
+    override fun setAlarm(webRequest: SetAlarmWebRequest) {
+        with(webRequest) {
+            queryNotificationPort.findByDeviceToken(deviceToken)?.let {
+                commandNotificationPort.deleteDeviceToken(it)
+            }
+
+            commandNotificationPort.saveAlarm(deviceToken, alarmTime)
+        }
     }
 }


### PR DESCRIPTION
알림 시간을 설정하는 API를 구현하겠습니다.

---

이번 API가 구현 자체는 쉬웠는데 진행하는 과정에서 바뀐 사항들이 몇 개 있습니다.. 😶

---

먼저는 Notification 엔티티에서 기존에는 alarmTime의 타입을 LocalDateTime으로 받고 있었는데 클라이언트와의 통신 과정 및 스케줄러 구현을 생각해보니 알림 시간은 String 타입의 XX:XX 와 같은 형식으로 받아온 뒤 스케줄러의 처리 과정에서 Date 타입을 String으로 변환해 처리하는 것이 더 간단할 것이라고 생각해 다음과 같이 alarmTime의 타입을 변경했습니다.

---

또 간단한 이슈로 queryPort에서 객체를 save 하는 로직을 수행하는 함수를 담고 있어 해당 함수를 이동 및 수정했습니다..!!

---

마지막으로는 기존에 구현한 deviceToken만을 저장하던 API를 구현한 것이 이번 알림 시간 설정 API를 구현하다 보니 굳이 이걸 따로 API로 분리해서 사용해야 하나..?? 하는 생각이 들어서 해당 API를 삭제 후 알림 설정 API에서 기존 FCM 토큰 유무에 따라 해당 토큰을 갱신하는 로직으로 대체했습니다..!!