### PR TITLE
푸시 알림 전송 기능 + 알림 스케줄러 기능 구현

### DIFF
--- a/src/main/kotlin/com/ondosee/OndoseeApplication.kt
+++ b/src/main/kotlin/com/ondosee/OndoseeApplication.kt
@@ -2,10 +2,12 @@ package com.ondosee
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import java.util.*
 
 @SpringBootApplication
 class OndoseeApplication
 
 fun main(args: Array<String>) {
+	TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
 	runApplication<OndoseeApplication>(*args)
 }

--- a/src/main/kotlin/com/ondosee/common/adapter/notification/QueryNotificationAdapter.kt
+++ b/src/main/kotlin/com/ondosee/common/adapter/notification/QueryNotificationAdapter.kt
@@ -1,6 +1,7 @@
 package com.ondosee.common.adapter.notification
 
 import com.ondosee.common.spi.notification.QueryNotificationPort
+import com.ondosee.domain.notification.domain.entity.Notification
 import com.ondosee.domain.notification.domain.repository.NotificationRepository
 import org.springframework.stereotype.Component
 
@@ -10,5 +11,9 @@ class QueryNotificationAdapter(
 ) : QueryNotificationPort {
     override fun existByDeviceToken(deviceToken: String): Boolean {
         return notificationRepository.existsByDeviceToken(deviceToken)
+    }
+
+    override fun findByAlarmTime(alarmTime: String): List<Notification> {
+        return notificationRepository.findByAlarmTime(alarmTime)
     }
 }

--- a/src/main/kotlin/com/ondosee/common/spi/notification/NotificationPort.kt
+++ b/src/main/kotlin/com/ondosee/common/spi/notification/NotificationPort.kt
@@ -1,0 +1,8 @@
+package com.ondosee.common.spi.notification
+
+import com.ondosee.domain.notification.domain.entity.NotificationAlarm
+
+interface NotificationPort {
+    fun sendSingleNotification(deviceToken: String, notificationAlarm: NotificationAlarm)
+    fun sendMultipleNotification(deviceTokens: List<String>, notificationAlarm: NotificationAlarm)
+}

--- a/src/main/kotlin/com/ondosee/common/spi/notification/QueryNotificationPort.kt
+++ b/src/main/kotlin/com/ondosee/common/spi/notification/QueryNotificationPort.kt
@@ -1,5 +1,8 @@
 package com.ondosee.common.spi.notification
 
+import com.ondosee.domain.notification.domain.entity.Notification
+
 interface QueryNotificationPort {
     fun existByDeviceToken(deviceToken: String): Boolean
+    fun findByAlarmTime(alarmTime: String): List<Notification>
 }

--- a/src/main/kotlin/com/ondosee/domain/notification/domain/entity/NotificationAlarm.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/domain/entity/NotificationAlarm.kt
@@ -1,0 +1,7 @@
+package com.ondosee.domain.notification.domain.entity
+
+data class NotificationAlarm(
+    val title: String,
+    val body: String,
+    val writer: String
+)

--- a/src/main/kotlin/com/ondosee/domain/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/domain/repository/NotificationRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface NotificationRepository : JpaRepository<Notification, Long> {
     fun existsByDeviceToken(deviceToken: String): Boolean
     fun deleteByDeviceToken(deviceToken: String)
+    fun findByAlarmTime(alarmTime: String): List<Notification>
 }

--- a/src/main/kotlin/com/ondosee/domain/notification/scheduler/NotificationScheduler.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/scheduler/NotificationScheduler.kt
@@ -1,0 +1,15 @@
+package com.ondosee.domain.notification.scheduler
+
+import com.ondosee.domain.notification.service.NotificationService
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class NotificationScheduler(
+    private val notificationService: NotificationService
+) {
+    @Scheduled(cron = "0 * * * * *")
+    fun sendNotificationAlarm() {
+        notificationService.sendAlarm()
+    }
+}

--- a/src/main/kotlin/com/ondosee/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/service/NotificationService.kt
@@ -4,4 +4,5 @@ import com.ondosee.domain.notification.presentation.web.req.SetAlarmWebRequest
 
 interface NotificationService {
     fun setAlarm(webRequest: SetAlarmWebRequest)
+    fun sendAlarm()
 }

--- a/src/main/kotlin/com/ondosee/domain/notification/service/NotificationServiceImpl.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/service/NotificationServiceImpl.kt
@@ -40,11 +40,12 @@ class NotificationServiceImpl(
                 writer = "ON°C"
             )
 
-            when (notificationList.size) {
-                1 -> notificationPort.sendSingleNotification(
+            if (notificationList.size == 1) {
+                notificationPort.sendSingleNotification(
                     deviceToken = notificationList.first().deviceToken,
                     notificationAlarm = notificationAlarm
-                ) else ->
+                )
+            } else {
                 notificationPort.sendMultipleNotification(
                     deviceTokens = notificationList.map { it.deviceToken },
                     notificationAlarm = notificationAlarm

--- a/src/main/kotlin/com/ondosee/domain/notification/service/NotificationServiceImpl.kt
+++ b/src/main/kotlin/com/ondosee/domain/notification/service/NotificationServiceImpl.kt
@@ -1,14 +1,20 @@
 package com.ondosee.domain.notification.service
 
 import com.ondosee.common.spi.notification.CommandNotificationPort
+import com.ondosee.common.spi.notification.NotificationPort
 import com.ondosee.common.spi.notification.QueryNotificationPort
+import com.ondosee.domain.notification.domain.entity.NotificationAlarm
 import com.ondosee.domain.notification.presentation.web.req.SetAlarmWebRequest
+import com.ondosee.thirdparty.firebase.data.enums.NotificationMessage
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 @Service
 @Transactional(rollbackFor = [Exception::class])
 class NotificationServiceImpl(
+    private val notificationPort: NotificationPort,
     private val queryNotificationPort: QueryNotificationPort,
     private val commandNotificationPort: CommandNotificationPort
 ) : NotificationService {
@@ -19,6 +25,31 @@ class NotificationServiceImpl(
             }
 
             commandNotificationPort.saveAlarm(deviceToken, alarmTime)
+        }
+    }
+
+    override fun sendAlarm() {
+        val currentTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH:mm"))
+
+        val notificationList = queryNotificationPort.findByAlarmTime(currentTime)
+
+        if (notificationList.isNotEmpty()) {
+            val notificationAlarm = NotificationAlarm(
+                title = NotificationMessage.ALARM_MESSAGE.title,
+                body = NotificationMessage.ALARM_MESSAGE.body,
+                writer = "ON°C"
+            )
+
+            when (notificationList.size) {
+                1 -> notificationPort.sendSingleNotification(
+                    deviceToken = notificationList.first().deviceToken,
+                    notificationAlarm = notificationAlarm
+                ) else ->
+                notificationPort.sendMultipleNotification(
+                    deviceTokens = notificationList.map { it.deviceToken },
+                    notificationAlarm = notificationAlarm
+                )
+            }
         }
     }
 }

--- a/src/main/kotlin/com/ondosee/global/config/ScheduleConfig.kt
+++ b/src/main/kotlin/com/ondosee/global/config/ScheduleConfig.kt
@@ -1,0 +1,8 @@
+package com.ondosee.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+class ScheduleConfig

--- a/src/main/kotlin/com/ondosee/thirdparty/firebase/FirebaseAdapter.kt
+++ b/src/main/kotlin/com/ondosee/thirdparty/firebase/FirebaseAdapter.kt
@@ -1,0 +1,42 @@
+package com.ondosee.thirdparty.firebase
+
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.MulticastMessage
+import com.ondosee.common.spi.notification.NotificationPort
+import com.ondosee.domain.notification.domain.entity.NotificationAlarm
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class FirebaseAdapter : NotificationPort {
+    private val firebaseInstance: FirebaseMessaging
+        get() = FirebaseMessaging.getInstance()
+
+    override fun sendSingleNotification(deviceToken: String, notificationAlarm: NotificationAlarm) {
+        val message = getMassageBuilderByNotification(notificationAlarm)
+            .setToken(deviceToken)
+            .build()
+        firebaseInstance.send(message)
+    }
+
+    override fun sendMultipleNotification(deviceTokens: List<String>, notificationAlarm: NotificationAlarm) {
+        val message = getMulticastMassageBuilderByNotification(notificationAlarm)
+            .addAllTokens(deviceTokens)
+            .build()
+        firebaseInstance.sendMulticastAsync(message)
+    }
+
+    private fun getMassageBuilderByNotification(notificationAlarm: NotificationAlarm) =
+        with(notificationAlarm) {
+            Message.builder()
+                .putData("title", title)
+                .putData("body", body)
+        }
+
+    private fun getMulticastMassageBuilderByNotification(notificationAlarm: NotificationAlarm) =
+        with(notificationAlarm) {
+            MulticastMessage.builder()
+                .putData("title", title)
+                .putData("body", body)
+        }
+}

--- a/src/main/kotlin/com/ondosee/thirdparty/firebase/data/enums/NotificationMessage.kt
+++ b/src/main/kotlin/com/ondosee/thirdparty/firebase/data/enums/NotificationMessage.kt
@@ -1,0 +1,11 @@
+package com.ondosee.thirdparty.firebase.data.enums
+
+enum class NotificationMessage(
+    val title: String,
+    val body: String
+) {
+    ALARM_MESSAGE(
+        title = "오늘의 날씨 특이사항은??",
+        body = "ON°C 가 설정하신 시간에 알림을 보냈어요 :)"
+    )
+}


### PR DESCRIPTION
푸시 알림 전송 기능 + 알림 스케줄러 기능을 구현했습니다.

--- 

먼저는 NotificationMessage 파일을 따로 enum class로 분리해서 사용했는데 현재 전송하는 알림 시간 관련 푸시 알림뿐만이 아니라 후에 추가 개발이 될 수도 있는 기상청 경보와 같은 상황에서도 유연하게 사용할 수 있도록 구현하려고 해당 방식을 사용했습니다.

---

또한 FirebaseAdapter에서 getMassageBuilderByNotification, getMulticastMassageBuilderByNotification 함수에서 사용되는 ~Message 객체에서는 여러 가지의 메시지 타입을 담아 보낼 수 있는데 이 중 핸드폰의 작업표시줄을 포함해 헤드업 방식으로 알림이 전달되는 Data 타입을 사용했습니다.

---

마지막으로 NotificationMessage의  ALARM_MESSAGE에 title과 body를 임의로 작성해 놓았는데 더 좋은 멘트가 있다면 추천 부탁드립니다..!!

---

아직 FCM 토큰을 따로 전달받지 못해 정확한 테스트를 시행해 보지는 못해서 후에 토큰을 발급받은 후 기능이 제대로 동작하지 않는다면 이에 맞춰서 추가적인 수정을 진행하겠습니다!